### PR TITLE
Add defaulting and status initialization to the reconciler.

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -63,6 +63,8 @@ func (reconciler *Reconciler) Reconcile(ctx context.Context, key string) error {
 	}
 
 	ingress := original.DeepCopy()
+	ingress.SetDefaults(ctx)
+	ingress.Status.InitializeConditions()
 
 	if err := reconciler.updateIngress(ingress); err != nil {
 		return fmt.Errorf("failed to update ingress: %w", err)


### PR DESCRIPTION
These have caused confusion because of a missing webhook in the tests in this repository.