### PR TITLE
Enable HA controller setup

### DIFF
--- a/cmd/kourier/main.go
+++ b/cmd/kourier/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"os"
 
+	"knative.dev/net-kourier/pkg/config"
+
 	kourierIngressController "knative.dev/net-kourier/pkg/reconciler/ingress"
 
 	"knative.dev/pkg/controller"
@@ -49,5 +51,5 @@ func main() {
 	// TODO: Improve reconcile to support multiple threads
 	controller.DefaultThreadsPerController = 1
 
-	sharedmain.Main("KourierIngressController", kourierIngressController.NewController)
+	sharedmain.Main(config.ControllerName, kourierIngressController.NewController)
 }

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -21,6 +21,47 @@ metadata:
   name: config-leader-election
   namespace: kourier-system
 data:
+  _example: |
+        ################################
+        #                              #
+        #    EXAMPLE CONFIGURATION     #
+        #                              #
+        ################################
+
+        # This block is not actually functional configuration,
+        # but serves to illustrate the available configuration
+        # options and document them in a way that is accessible
+        # to users that `kubectl edit` this config map.
+        #
+        # These sample configuration options may be copied out of
+        # this example block and unindented to be in the data block
+        # to actually change the configuration.
+
+        # resourceLock controls which API resource is used as the basis for the
+        # leader election lock. Valid values are:
+        #
+        # - leases -> use the coordination API
+        # - configmaps -> use configmaps
+        # - endpoints -> use endpoints
+        resourceLock: "leases"
+
+        # leaseDuration is how long non-leaders will wait to try to acquire the
+        # lock; 15 seconds is the value used by core kubernetes controllers.
+        leaseDuration: "15s"
+        # renewDeadline is how long a leader will try to renew the lease before
+        # giving up; 10 seconds is the value used by core kubernetes controllers.
+        renewDeadline: "10s"
+        # retryPeriod is how long the leader election client waits between tries of
+        # actions; 2 seconds is the value used by core kubernetes controllers.
+        retryPeriod: "2s"
+        # enabledComponents is a comma-delimited list of component names for which
+        # leader election is enabled. Valid values are:
+        # - controller
+        # - hpaautoscaler
+        # - certcontroller
+        # - istiocontroller
+        # - nscontroller
+        # - kourier
   enabledComponents: kourier
 ---
 apiVersion: v1

--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -16,6 +16,14 @@ metadata:
   namespace: kourier-system
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: kourier-system
+data:
+  enabledComponents: kourier
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: kourier
@@ -123,6 +131,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "endpoints", "namespaces", "services", "secrets", "configmaps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["networking.internal.knative.dev"]
     resources: ["clusteringresses","ingresses"]
     verbs: ["get", "list", "watch"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 const (
+	ControllerName = "kourier"
+
 	InternalServiceName = "kourier-internal"
 	ExternalServiceName = "kourier"
 


### PR DESCRIPTION
- Leader election is enabled/disabled by adding the kourier controller name to the configmap `config-leader-election` under the key `enabledComponents`. 
- Added permissions for k8s [leases](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#leaselist-v1-coordination-k8s-io) as it is used by the leader election to establish if there's an actual leader or not. 
- Changed the controller name, as it's used to create a lease with it. Leases' name can't contain uppercase characters. 