### PR TITLE
Re-enable TestRetry

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,8 +21,6 @@ initialize $@  --skip-istio-addon
 
 go_test_e2e -timeout=20m -parallel=12 \
 	    ./vendor/knative.dev/serving/test/conformance/ingress \
-            `# TODO(#30): TestRetry is blocking the nightly release.` \
-	     -run="Test[^R]" \
 	    --ingressClass=kourier.ingress.networking.knative.dev || fail_test
 
 success


### PR DESCRIPTION
This reverts commit 9e073df0f8a1e52889f5cebbe7eac8f945eb53f5.
It looks like https://github.com/knative/net-kourier/pull/33 fixed the test.