### PR TITLE
Remove unnecesary XDS snapshot update

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -93,17 +93,7 @@ func (reconciler *Reconciler) deleteIngress(namespace, name string) error {
 		reconciler.statusManager.CancelIngressProbing(ingress)
 	}
 
-	err := reconciler.CurrentCaches.DeleteIngressInfo(name, namespace, reconciler.kubeClient)
-	if err != nil {
-		return err
-	}
-
-	snapshot, err := reconciler.CurrentCaches.ToEnvoySnapshot()
-	if err != nil {
-		return err
-	}
-
-	return reconciler.EnvoyXDSServer.SetSnapshot(&snapshot, nodeID)
+	return reconciler.CurrentCaches.DeleteIngressInfo(name, namespace, reconciler.kubeClient)
 }
 
 func (reconciler *Reconciler) updateIngress(ingress *v1alpha1.Ingress) error {


### PR DESCRIPTION
The OnEviction callback will take care of updating the XDS when the cluster is already removed. 