### PR TITLE
Fix module usage in presubmit tests and update scripts.

### DIFF
--- a/hack/tools.go
+++ b/hack/tools.go
@@ -8,6 +8,7 @@ import (
 	_ "knative.dev/serving/test/conformance/ingress"
 	_ "knative.dev/serving/test/test_images/flaky"
 	_ "knative.dev/serving/test/test_images/grpc-ping"
+	_ "knative.dev/serving/test/test_images/helloworld"
 	_ "knative.dev/serving/test/test_images/httpproxy"
 	_ "knative.dev/serving/test/test_images/runtime"
 	_ "knative.dev/serving/test/test_images/timeout"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -23,6 +23,9 @@ set -o pipefail
 
 cd ${ROOT_DIR}
 
+# We need these flags for things to work properly.
+export GO111MODULE=on
+
 # This controls the release branch we track.
 VERSION="master"
 

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -26,6 +26,7 @@
 export DISABLE_MD_LINTING=1
 
 export GO111MODULE=on
+export GOFLAGS=-mod=vendor
 
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 

--- a/vendor/knative.dev/serving/test/test_images/helloworld/README.md
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/README.md
@@ -1,0 +1,23 @@
+# Helloworld test image
+
+This directory contains the test image used in the helloworld e2e test.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called, the server emits a "hello world" message.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+To run this image as just a Route and Configuration:
+
+`ko apply -f helloworld.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"knative.dev/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Hello world received a request.")
+	fmt.Fprintln(w, "Hello World! How about some tasty noodles?")
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Hello world app started.")
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/helloworld.yaml
@@ -1,0 +1,40 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Configuration
+metadata:
+  name: configuration-example
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - # This is the Go import path for the binary to containerize
+        # and substitute here.
+        image: ko://knative.dev/serving/test/test_images/helloworld
+        readinessProbe:
+          httpGet:
+            path: /
+          initialDelaySeconds: 3
+---
+apiVersion: serving.knative.dev/v1
+kind: Route
+metadata:
+  name: route-example
+  namespace: default
+spec:
+  traffic:
+  - configurationName: configuration-example
+    percent: 100

--- a/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
+++ b/vendor/knative.dev/serving/test/test_images/helloworld/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/helloworld

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -745,6 +745,7 @@ knative.dev/serving/test/conformance/ingress
 knative.dev/serving/test/test_images/flaky
 knative.dev/serving/test/test_images/grpc-ping
 knative.dev/serving/test/test_images/grpc-ping/proto
+knative.dev/serving/test/test_images/helloworld
 knative.dev/serving/test/test_images/httpproxy
 knative.dev/serving/test/test_images/runtime
 knative.dev/serving/test/test_images/runtime/handlers


### PR DESCRIPTION
The presubmit tests don't seem to use the vendor directory. This fixes that.