### PR TITLE
Aligning test call with net-istio.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,8 +22,8 @@ initialize "$@" --skip-istio-addon
 failed=0
 
 go_test_e2e -timeout=20m -parallel=12 \
-	    ./vendor/knative.dev/serving/test/conformance/ingress \
-	    --ingressClass=kourier.ingress.networking.knative.dev || failed=1
+	knative.dev/serving/test/conformance/ingress \
+	--ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Scale up components for HA tests.
 for deployment in 3scale-kourier-control 3scale-kourier-gateway; do
@@ -39,7 +39,7 @@ wait_for_leader_controller || failed=1
 sleep 30
 
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" \
-            --ingressClass=kourier.ingress.networking.knative.dev || failed=1
+  --ingressClass=kourier.ingress.networking.knative.dev || failed=1
 
 # Scale back HA components.
 for deployment in 3scale-kourier-control 3scale-kourier-gateway; do

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -26,7 +26,6 @@
 export DISABLE_MD_LINTING=1
 
 export GO111MODULE=on
-export GOFLAGS=-mod=vendor
 
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 


### PR DESCRIPTION
Our integration tests are still broken. Trying to flesh out what exactly is causing it.

/hold

We know it worked if the integration test suite actually runs. See https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_net-kourier/74/pull-knative-net-kourier-integration-tests/1262687126735032320 for the failure.