### PR TITLE
Bring back - Wait for Static IP to be hooked up

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -47,7 +47,7 @@ function test_setup() {
   # Wait for pods to be running.
   echo ">> Waiting for Kourier components to be running..."
   wait_until_pods_running "${KOURIER_NAMESPACE}" || return 1
-  wait_until_service_has_external_ip "${KOURIER_NAMESPACE}" kourier || return 1
+  wait_until_service_has_external_http_address "${KOURIER_NAMESPACE}" kourier || return 1
 }
 
 # Add function call to trap


### PR DESCRIPTION
Bring back changes from https://github.com/knative/net-kourier/commit/205bd4033e7ef70fb0abc64b5641f97536073b97 that very recently overridden.