### PR TITLE
Preallocate slices.

### DIFF
--- a/pkg/envoy/headers.go
+++ b/pkg/envoy/headers.go
@@ -22,8 +22,7 @@ import (
 )
 
 func headersToAdd(headers map[string]string) []*core.HeaderValueOption {
-	var res []*core.HeaderValueOption
-
+	res := make([]*core.HeaderValueOption, 0, len(headers))
 	for headerName, headerVal := range headers {
 		header := &core.HeaderValueOption{
 			Header: &core.HeaderValue{

--- a/pkg/envoy/listener.go
+++ b/pkg/envoy/listener.go
@@ -152,8 +152,7 @@ func createFilters(manager *httpconnmanagerv2.HttpConnectionManager) ([]*listene
 }
 
 func createFilterChainsForTLS(manager *httpconnmanagerv2.HttpConnectionManager, sniMatches []*SNIMatch) ([]*listener.FilterChain, error) {
-	var res []*listener.FilterChain
-
+	res := make([]*listener.FilterChain, 0, len(sniMatches))
 	for _, sniMatch := range sniMatches {
 		// The connection manager received in the params contains all the
 		// matching rules. For each sniMatch, we just need the rules defined for

--- a/pkg/generator/caches.go
+++ b/pkg/generator/caches.go
@@ -255,8 +255,7 @@ func (caches *Caches) getNewSnapshotVersion() (string, error) {
 }
 
 func (caches *Caches) externalVirtualHosts() []*route.VirtualHost {
-	var res []*route.VirtualHost
-
+	res := make([]*route.VirtualHost, 0, len(caches.translatedIngresses))
 	for _, translatedIngress := range caches.translatedIngresses {
 		res = append(res, translatedIngress.externalVirtualHosts...)
 	}
@@ -265,8 +264,7 @@ func (caches *Caches) externalVirtualHosts() []*route.VirtualHost {
 }
 
 func (caches *Caches) clusterLocalVirtualHosts() []*route.VirtualHost {
-	var res []*route.VirtualHost
-
+	res := make([]*route.VirtualHost, 0, len(caches.translatedIngresses))
 	for _, translatedIngress := range caches.translatedIngresses {
 		res = append(res, translatedIngress.internalVirtualHosts...)
 	}
@@ -275,8 +273,7 @@ func (caches *Caches) clusterLocalVirtualHosts() []*route.VirtualHost {
 }
 
 func (caches *Caches) sniMatches() []*envoy.SNIMatch {
-	var res []*envoy.SNIMatch
-
+	res := make([]*envoy.SNIMatch, 0, len(caches.translatedIngresses))
 	for _, translatedIngress := range caches.translatedIngresses {
 		res = append(res, translatedIngress.sniMatches...)
 	}

--- a/pkg/generator/cluster_cache.go
+++ b/pkg/generator/cluster_cache.go
@@ -82,9 +82,9 @@ func (cc *ClustersCache) setExpiration(clusterName string, ingressName string, i
 }
 
 func (cc *ClustersCache) list() []envoycache.Resource {
-	var res []envoycache.Resource
 	cc.logger.Debug("listing clusters")
 
+	res := make([]envoycache.Resource, 0, cc.clusters.ItemCount())
 	for _, cluster := range cc.clusters.Items() {
 		cc.logger.Debugf("listing cluster %#v", cluster.Object.(*v2.Cluster))
 		res = append(res, cluster.Object.(envoycache.Resource))

--- a/pkg/generator/cluster_cache_test.go
+++ b/pkg/generator/cluster_cache_test.go
@@ -55,7 +55,7 @@ func TestSetSeveralClusters(t *testing.T) {
 	cache.set(&testCluster2, "some_ingress_name", "some_ingress_namespace")
 
 	list := cache.list()
-	var names []string
+	names := make([]string, 0, len(list))
 	for _, cluster := range list {
 		names = append(names, cluster.(*envoy_api_v2.Cluster).Name)
 	}

--- a/pkg/reconciler/ingress/lister.go
+++ b/pkg/reconciler/ingress/lister.go
@@ -66,7 +66,6 @@ func (l *gatewayPodTargetLister) ListProbeTargets(ctx context.Context, ing *v1al
 }
 
 func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, gatewayIps []string) ([]status.ProbeTarget, error) {
-	var targets []status.ProbeTarget
 	localDomainName := network.GetClusterDomainName()
 	ips := sets.NewString()
 
@@ -74,6 +73,7 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, gatewayIp
 		ips.Insert(ip)
 	}
 
+	targets := make([]status.ProbeTarget, 0, len(ing.Spec.Rules))
 	for _, rule := range ing.Spec.Rules {
 		var target status.ProbeTarget
 
@@ -108,8 +108,7 @@ func (l *gatewayPodTargetLister) getIngressUrls(ing *v1alpha1.Ingress, gatewayIp
 }
 
 func domainsToURL(domains []string, scheme string) []*url.URL {
-	var urls []*url.URL
-
+	urls := make([]*url.URL, 0, len(domains))
 	for _, domain := range domains {
 		url := &url.URL{
 			Scheme: scheme,


### PR DESCRIPTION
Most of the slices preallocated have a fixed length anyway.

For those where we use the rest operator, we at least preallocate the minimum size. The slice will grow automatically beyond that if necessary.