### PR TITLE
Enables zipkin with sampling set to 0 by default.

### DIFF
--- a/deploy/kourier-knative.yaml
+++ b/deploy/kourier-knative.yaml
@@ -341,6 +341,20 @@ data:
                 port_value: 18000
           http2_protocol_options: {}
           type: STRICT_DNS
+        - name: zipkin
+          connect_timeout: 1s
+          hosts:
+            - socket_address:
+                address: "zipkin"
+                port_value: 443
+          type: STRICT_DNS
+    tracing:
+      http:
+        name: envoy.zipkin
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.trace.v2.ZipkinConfig
+          collector_cluster: zipkin
+          collector_endpoint: "/api/v1/spans"
     admin:
       access_log_path: "/dev/stdout"
       address:

--- a/pkg/envoy/http_connection_manager.go
+++ b/pkg/envoy/http_connection_manager.go
@@ -23,9 +23,11 @@ import (
 	accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	envoy_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	httpconnectionmanagerv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/wrappers"
 )
 
 func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionmanagerv2.HttpConnectionManager {
@@ -52,6 +54,17 @@ func NewHTTPConnectionManager(virtualHosts []*route.VirtualHost) httpconnectionm
 			RouteConfig: &v2.RouteConfiguration{
 				Name:         "local_route",
 				VirtualHosts: virtualHosts,
+			},
+		},
+		GenerateRequestId: &wrappers.BoolValue{
+			Value: true,
+		},
+		// TODO: Read actual tracing information from knative configmaps
+		// HACK: right now, in order to forward the x-b3-* headers properly, we need to enable zipkin tracing
+		// even if it's set to 0% sampling.
+		Tracing: &httpconnectionmanagerv2.HttpConnectionManager_Tracing{
+			RandomSampling: &envoy_type.Percent{
+				Value: 0,
 			},
 		},
 		HttpFilters: filters,


### PR DESCRIPTION
This should be fixed in the next versions of envoy, when we can actually add the custom header x-b3-* directly. (currently, those headers can be manipulated directly) 

With those changes, we can pass the failing test "runtime.TestShouldHaveHeadersSet"

In a next iteration we should add proper tracing support. 